### PR TITLE
初步爬取网页新闻的标题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,18 @@
         </profile>
     </profiles>
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.15.3</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/src/main/java/com/github/suzhaoyong/Main.java
+++ b/src/main/java/com/github/suzhaoyong/Main.java
@@ -1,7 +1,91 @@
 package com.github.suzhaoyong;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 public class Main {
+    static final String INDEX_PAGE_URL = "https://sina.cn";
+
     public static void main(String[] args) {
-        System.out.println("这是个爬虫项目");
+        List<String> linkPool = new ArrayList<>();
+        Set<String> processedLinks = new HashSet<>();
+        linkPool.add(INDEX_PAGE_URL);
+        while (true) {
+            if (linkPool.isEmpty()) {
+                break;
+            }
+            String link = linkPool.remove(linkPool.size() - 1);
+            if (processedLinks.contains(link)) {
+                continue;
+            }
+            if (isInterestLink(link)) {
+                if (link.startsWith("//")) {
+                    link = "https:" + link;
+                }
+                System.out.println(link);
+                Document doc = httpGetAndParseHtml(link);
+                doc.select("a").stream().map(aTag -> aTag.attr("href")).forEach(linkPool::add);
+
+                storeIntoDataBaseIfItIsNewsPage(doc);
+                processedLinks.add(link);
+            }
+        }
     }
+
+
+    private static boolean isInterestLink(String link) {
+        return (isNewsLink(link) || isIndexPageLink(link)) && isNotLoginLink(link);
+    }
+
+    private static boolean isIndexPageLink(String link) {
+        return INDEX_PAGE_URL.equals(link);
+    }
+
+    private static boolean isNewsLink(String link) {
+        return link.contains("news.sina.cn");
+    }
+
+    private static boolean isNotLoginLink(String link) {
+        return !link.contains("passport.sina.cn");
+    }
+
+    private static Document httpGetAndParseHtml(String link) {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpGet httpGet = new HttpGet(link);
+        httpGet.setHeader("User-Agent", "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1");
+        try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+            System.out.println(response.getStatusLine());
+            HttpEntity entity = response.getEntity();
+            String html = EntityUtils.toString(entity);
+            return Jsoup.parse(html);
+        } catch (ClientProtocolException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private static void storeIntoDataBaseIfItIsNewsPage(Document doc) {
+        ArrayList<Element> articleTags = doc.select("article");
+        if (!articleTags.isEmpty()) {
+            String title = articleTags.get(0).child(0).text();
+            System.out.println(title);
+        }
+    }
+
 }


### PR DESCRIPTION
1.获取并解析网页<a>https://sina.cn</a>
2.解析的数据处理并获取`<a>`标签放入链接池中并不断遍历直到为空
3.处理并获取`<article>`标签获取新闻页面标题
4.打印出标题

pom.xml
添加 `httpclient`,`jsoup` 第三方依赖