### PR TITLE
引入 mysql 插件，创建数据库和表

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ target
 hs_err_pid*
 
 *.iml
+# database file
+/mysql

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <artifactId>jsoup</artifactId>
             <version>1.15.3</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.46</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/src/main/resources/db/Database_Initialization.sql
+++ b/src/main/resources/db/Database_Initialization.sql
@@ -1,0 +1,22 @@
+create database if not exists octopus_news;
+use octopus_news;
+
+create table if not exists LINKS_TO_BE_PROCESSED
+(
+    link varchar(100)
+);
+
+create table if not exists LINKS_ALREADY_PROCESSED
+(
+    link varchar(100)
+);
+
+create table if not exists NEWS
+(
+    id          bigint primary key auto_increment,
+    title       text,
+    content     text,
+    url         varchar(100) not null,
+    created_at  timestamp default now(),
+    modified_at timestamp default now()
+);


### PR DESCRIPTION
docker 中下载 mysql 镜像
·在命名行中进入当前项目并创建 `octopus-news` 容器，绑定 `3306` 端口，数据存储在本地中
 `docker run --name octopus-news -p 3306:3306 -v `pwd`/mysql:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=qwerdfgh -d mysql:5.7.40`

·在项目中`src/main/resources/db/Database_Initialization.sql` 文件初始化数据库

·gitignore 文件忽略本地数据库文件