### PR TITLE
引入 flyway 数据库自动化迁移，删除 tables 需要重建数据库或重启 mysql 容器

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
             <version>5.6.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+            <version>8.4.3</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -139,6 +144,16 @@
                         <version>4.7.3</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <version>5.2.4</version>
+                <configuration>
+                    <url>jdbc:mysql://localhost:3306/octopus_news?useSSL=false</url>
+                    <user>root</user>
+                    <password>qwerdfgh</password>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/src/main/resources/db/migration/V1__Create_tables.sql
@@ -1,0 +1,19 @@
+create table if not exists LINKS_TO_BE_PROCESSED
+(
+    link varchar(100)
+);
+
+create table if not exists LINKS_ALREADY_PROCESSED
+(
+    link varchar(100)
+);
+
+create table if not exists NEWS
+(
+    id          bigint primary key auto_increment,
+    title       text,
+    content     text,
+    url         varchar(100) not null,
+    created_at  timestamp default now(),
+    modified_at timestamp default now()
+);

--- a/src/main/resources/db/migration/V2__Init_data.sql
+++ b/src/main/resources/db/migration/V2__Init_data.sql
@@ -1,0 +1,2 @@
+insert into LINKS_TO_BE_PROCESSED (link)
+values ('https://sina.cn');


### PR DESCRIPTION
详情请查看🔎：[issues#9](https://github.com/suzhaoyong/octopus-news/issues/9)  
谢谢张老师指点